### PR TITLE
docs: add workflow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,27 @@ ShadowMap is a Rust-powered open-source framework for **subdomain enumeration, v
   - Software fingerprinting (frameworks, servers, CDNs)  
   - Subdomain takeover detection (AWS S3, Azure, CloudFront, GitHub Pages, etc.)  
 - 📊 **Export Formats** → CSV, JSON, TXT (ready for pipelines or reporting)  
-- 🛡 **False Positive Reduction** → heuristic checks + fallback validation  
+- 🛡 **False Positive Reduction** → heuristic checks + fallback validation
+
+## 🔄 Workflow
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Parse CLI args]
+    B --> C[Create output directory]
+    C --> D[Build HTTP client]
+    D --> E[Enumerate subdomains via crt.sh]
+    E --> F[Validate & normalize domains]
+    F --> G[DNS resolution]
+    G --> H[Port scan]
+    H --> I[Header & TLS check]
+    I --> J[CORS misconfiguration check]
+    J --> K[Software fingerprinting]
+    K --> L[Cloud/SaaS recon]
+    L --> M[Subdomain takeover detection]
+    M --> N[Generate reports]
+    N --> O[End]
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- document ShadowMap's recon pipeline with a workflow diagram

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c4cc36025c832698f289c6bc1f32fd