### PR TITLE
[shadowmap] feat: add minimal web UI

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -8,7 +8,8 @@ use trust_dns_resolver::{config::*, TokioAsyncResolver};
 
 use crate::constants::DNS_TIMEOUT;
 
-pub async fn create_secure_resolver() -> Result<TokioAsyncResolver, Box<dyn std::error::Error>> {
+pub async fn create_secure_resolver(
+) -> Result<TokioAsyncResolver, Box<dyn std::error::Error + Send + Sync>> {
     let mut config = ResolverConfig::default();
     config.add_name_server(NameServerConfig {
         socket_addr: "8.8.8.8:53".parse()?,

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -16,10 +16,10 @@ pub async fn crtsh_enum_async(
     client: &Client,
     domain: &str,
     max_retries: usize,
-) -> Result<HashSet<String>, Box<dyn std::error::Error>> {
+) -> Result<HashSet<String>, Box<dyn std::error::Error + Send + Sync>> {
     let url = format!("https://crt.sh/?q=%25.{}&output=json", domain);
     let mut retries = 0;
-    let mut last_error: Option<Box<dyn std::error::Error>> = None;
+    let mut last_error: Option<Box<dyn std::error::Error + Send + Sync>> = None;
 
     while retries < max_retries {
         let resp = client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,4 +128,3 @@ pub async fn run(args: Args) -> Result<String, Box<dyn std::error::Error + Send 
     println!("[*] Recon complete. Outputs in: {}", output_dir);
     Ok(output_dir)
 }
-

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -19,7 +19,7 @@ pub fn write_outputs(
     maps: ReconMaps<'_>,
     output_dir: &str,
     domain: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let txt_file = format!("{}/{}_subdomains.txt", output_dir, domain);
     let mut file = File::create(&txt_file)?;
     for sub in subs.iter().sorted() {

--- a/web/index.html
+++ b/web/index.html
@@ -1,57 +1,84 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<title>ShadowMap Dashboard</title>
-<script>
-const API_URL = 'http://localhost:8080';
-
-async function submitJob() {
-  const domain = document.getElementById('domain').value;
-  const token = document.getElementById('token').value;
-  const res = await fetch(API_URL + '/jobs', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token
-    },
-    body: JSON.stringify({domain})
-  });
-  const data = await res.json();
-  document.getElementById('jobId').innerText = data.id;
-}
-
-async function checkStatus() {
-  const id = document.getElementById('statusId').value;
-  const token = document.getElementById('token').value;
-  const res = await fetch(API_URL + '/jobs/' + id, {
-    headers: { 'Authorization': 'Bearer ' + token }
-  });
-  const data = await res.json();
-  document.getElementById('statusResult').innerText = data.status;
-}
-
-async function downloadReport() {
-  const id = document.getElementById('statusId').value;
-  const token = document.getElementById('token').value;
-  const res = await fetch(API_URL + '/jobs/' + id + '/report', {
-    headers: { 'Authorization': 'Bearer ' + token }
-  });
-  const txt = await res.text();
-  document.getElementById('report').textContent = txt;
-}
-</script>
+  <meta charset="UTF-8" />
+  <title>ShadowMap</title>
+  <style>
+    :root { --bg:#f5f5f5; --fg:#333; --accent:#0077ff; }
+    body { margin:0; font-family:sans-serif; background:var(--bg); color:var(--fg); display:flex; justify-content:center; }
+    .card { background:#fff; max-width:600px; width:100%; padding:2rem; margin-top:3rem; border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.1); }
+    label { display:block; margin-top:1rem; }
+    input { width:100%; padding:0.5rem; margin-top:0.25rem; box-sizing:border-box; }
+    button { margin-top:1rem; width:100%; padding:0.75rem; background:var(--accent); color:#fff; border:none; cursor:pointer; }
+    button:disabled { background:#888; cursor:default; }
+    .status { margin-top:1rem; }
+    pre { background:#eee; padding:1rem; border-radius:4px; overflow:auto; max-height:300px; }
+    .hidden { display:none; }
+  </style>
 </head>
 <body>
-<h1>ShadowMap</h1>
-<div>
-Token: <input id="token" type="text" value="testtoken"><br/>
-Domain: <input id="domain" type="text"><button onclick="submitJob()">Submit</button>
-<p>Job ID: <span id="jobId"></span></p>
-</div>
-<div>
-Job ID: <input id="statusId" type="text"><button onclick="checkStatus()">Check Status</button><button onclick="downloadReport()">Download Report</button>
-<p>Status: <span id="statusResult"></span></p>
-<pre id="report"></pre>
-</div>
+  <div class="card">
+    <h1>ShadowMap</h1>
+    <label>Token
+      <input id="token" type="text" value="testtoken" />
+    </label>
+    <label>Domain
+      <input id="domain" type="text" placeholder="example.com" />
+    </label>
+    <button id="start">Start Scan</button>
+    <p class="status">Job: <span id="job"></span> – Status: <span id="status">idle</span></p>
+    <pre id="report" class="hidden"></pre>
+  </div>
+  <script>
+    const API_URL = 'http://localhost:8080';
+    const tokenInput = document.getElementById('token');
+    const domainInput = document.getElementById('domain');
+    const startBtn = document.getElementById('start');
+    const statusEl = document.getElementById('status');
+    const jobEl = document.getElementById('job');
+    const reportEl = document.getElementById('report');
+
+    startBtn.addEventListener('click', async () => {
+      const token = tokenInput.value.trim();
+      const domain = domainInput.value.trim();
+      if (!domain) return;
+      startBtn.disabled = true;
+      statusEl.textContent = 'queued';
+      jobEl.textContent = '';
+      reportEl.classList.add('hidden');
+      const res = await fetch(API_URL + '/jobs', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + token,
+        },
+        body: JSON.stringify({ domain }),
+      });
+      const { id } = await res.json();
+      jobEl.textContent = id;
+      poll(id, token);
+    });
+
+    function poll(id, token) {
+      const timer = setInterval(async () => {
+        const res = await fetch(API_URL + '/jobs/' + id, {
+          headers: { 'Authorization': 'Bearer ' + token },
+        });
+        const data = await res.json();
+        statusEl.textContent = data.status;
+        if (data.status === 'completed' || data.status === 'failed') {
+          clearInterval(timer);
+          startBtn.disabled = false;
+          if (data.status === 'completed') {
+            const rep = await fetch(API_URL + '/jobs/' + id + '/report', {
+              headers: { 'Authorization': 'Bearer ' + token },
+            });
+            reportEl.textContent = await rep.text();
+            reportEl.classList.remove('hidden');
+          }
+        }
+      }, 2000);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add minimalist HTML dashboard with automatic job polling
- ensure helper functions return `Send + Sync` errors for async compatibility

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c522a91f9c8326be401dcf5ba8e024