### PR TITLE
[shadowmap] feat: revamp GUI with glassmorphism

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "gui")]
 
-use eframe::egui;
+use eframe::egui::{self, Color32, CornerRadius, Frame, Layout, Stroke, Visuals};
 use shadowmap::{run, Args};
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
@@ -23,6 +23,10 @@ impl Default for App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Ensure predictable visuals and transparent background for a
+        // glassmorphism-inspired design.
+        ctx.set_visuals(Visuals::dark());
+
         if let Some(rx) = &self.worker {
             if let Ok(msg) = rx.try_recv() {
                 self.status = msg;
@@ -31,35 +35,56 @@ impl eframe::App for App {
                 ctx.request_repaint();
             }
         }
+        let frame = Frame::new()
+            .fill(Color32::from_rgba_unmultiplied(18, 18, 18, 180))
+            .stroke(Stroke::new(1.0, Color32::WHITE.linear_multiply(0.1)))
+            .corner_radius(CornerRadius::same(12));
 
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("ShadowMap");
-            ui.horizontal(|ui| {
-                ui.label("Domain:");
-                ui.text_edit_singleline(&mut self.domain);
-            });
-            if ui.button("Run Scan").clicked() && self.worker.is_none() {
-                let domain = self.domain.clone();
-                let (tx, rx) = mpsc::channel();
-                thread::spawn(move || {
-                    let rt = tokio::runtime::Runtime::new().unwrap();
-                    let args = Args {
-                        domain,
-                        concurrency: 100,
-                        timeout: 10,
-                        retries: 2,
-                    };
-                    let msg = match rt.block_on(run(args)) {
-                        Ok(out) => format!("Scan complete. Output at {out}"),
-                        Err(e) => format!("Scan failed: {e}"),
-                    };
-                    let _ = tx.send(msg);
+        egui::CentralPanel::default().frame(frame).show(ctx, |ui| {
+            ui.with_layout(Layout::top_down(egui::Align::Min), |ui| {
+                ui.heading("ShadowMap");
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    ui.label("Domain");
+                    let text_edit =
+                        egui::TextEdit::singleline(&mut self.domain).hint_text("example.com");
+                    ui.add(text_edit);
+                    let run_button = ui.add_enabled(
+                        self.worker.is_none() && !self.domain.is_empty(),
+                        egui::Button::new("Run"),
+                    );
+                    if run_button.clicked() {
+                        let domain = self.domain.clone();
+                        let (tx, rx) = mpsc::channel();
+                        thread::spawn(move || {
+                            let rt = tokio::runtime::Runtime::new().unwrap();
+                            let args = Args {
+                                domain,
+                                concurrency: 100,
+                                timeout: 10,
+                                retries: 2,
+                            };
+                            let msg = match rt.block_on(run(args)) {
+                                Ok(out) => format!("Scan complete. Output at {out}"),
+                                Err(e) => format!("Scan failed: {e}"),
+                            };
+                            let _ = tx.send(msg);
+                        });
+                        self.status = "Scanning...".to_string();
+                        self.worker = Some(rx);
+                    }
                 });
-                self.status = "Scanning...".to_string();
-                self.worker = Some(rx);
-            }
-            ui.separator();
-            ui.label(&self.status);
+                ui.add_space(10.0);
+                ui.separator();
+                let color = if self.status.starts_with("Scan complete") {
+                    Color32::GREEN
+                } else if self.status.starts_with("Scan failed") {
+                    Color32::RED
+                } else {
+                    Color32::WHITE
+                };
+                ui.colored_label(color, &self.status);
+            });
         });
     }
 }
@@ -70,6 +95,5 @@ fn main() -> eframe::Result<()> {
         "ShadowMap",
         options,
         Box::new(|_cc| Ok(Box::new(App::default()))),
-
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,7 @@ use reporting::{write_outputs, ReconMaps};
 use std::path::Path;
 use takeover::check_subdomain_takeover;
 
-pub async fn run(args: Args) -> Result<String, Box<dyn std::error::Error>> {
-
+pub async fn run(args: Args) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let timestamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
     let output_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("recon_results")
@@ -133,4 +132,3 @@ pub async fn run(args: Args) -> Result<String, Box<dyn std::error::Error>> {
     println!("[*] Recon complete. Outputs in: {}", output_dir);
     Ok(output_dir)
 }
-


### PR DESCRIPTION
## Summary
- style(gui): redesign GUI with glassmorphism-inspired panel and improved layout
- fix: broaden run error type for async tasks

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --features gui -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c6a34e0eb08326922625a8e080c1c2