### PR TITLE
[cli] fix: handle broken pipe and gui disconnect

### DIFF
--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -68,7 +68,7 @@ pub async fn crtsh_enum_async(
         retries += 1;
         if retries < max_retries {
             let delay = Duration::from_secs(2_u64.pow(retries as u32));
-            println!(
+            eprintln!(
                 "[!] Retry {}/{} due to error: {:?}",
                 retries, max_retries, last_error
             );


### PR DESCRIPTION
## Summary
- log to stderr to avoid panics when stdout is closed
- show an error in the GUI when the worker thread disconnects
- send retry diagnostics to stderr

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `cargo test --workspace` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb9e95e08326be648515f19ff81d