### PR TITLE
[shadowmap] docs: add sbom security workflow

### DIFF
--- a/.github/actions/security-scan/action.yml
+++ b/.github/actions/security-scan/action.yml
@@ -1,0 +1,38 @@
+name: "ShadowMap Security Scan"
+description: "Generate a CycloneDX SBOM and scan it with Grype"
+inputs:
+  bom-file:
+    description: "Filename for the generated CycloneDX SBOM"
+    required: false
+    default: "bom.json"
+  report-file:
+    description: "Optional JSON file to store Grype results"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: Ensure cargo-cyclonedx is installed
+      shell: bash
+      run: |
+        if ! cargo cyclonedx --version >/dev/null 2>&1; then
+          cargo install cargo-cyclonedx --locked
+        fi
+
+    - name: Ensure grype is installed
+      shell: bash
+      run: |
+        if ! command -v grype >/dev/null 2>&1; then
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
+        fi
+
+    - name: Run security scan
+      shell: bash
+      run: |
+        ARGS=("${{ inputs.bom-file }}")
+        if [[ -n "${{ inputs.report-file }}" ]]; then
+          ARGS+=("${{ inputs.report-file }}")
+        fi
+        ./scripts/security-scan.sh "${ARGS[@]}"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,43 @@
+name: Supply chain security scan
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - Cargo.toml
+      - Cargo.lock
+      - scripts/security-scan.sh
+      - .github/actions/security-scan/**
+      - .github/workflows/security-scan.yml
+  pull_request:
+    paths:
+      - '**/*.rs'
+      - Cargo.toml
+      - Cargo.lock
+      - scripts/security-scan.sh
+      - .github/actions/security-scan/**
+      - .github/workflows/security-scan.yml
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate SBOM and scan for vulnerabilities
+        uses: ./.github/actions/security-scan
+        with:
+          bom-file: shadowmap-bom.json
+          report-file: grype-report.json
+
+      - name: Upload scan artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shadowmap-security-scan
+          path: |
+            shadowmap-bom.json
+            grype-report.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -56,14 +56,20 @@ ty guide referenced in this task.
    ```
    Refer to the [Grype README](https://github.com/anchore/grype) for macOS and Windows alternatives.
 
-3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled:
+3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled. Either emit the file to the current directory or read it from Cargo's default `target/cyclonedx` folder:
    ```bash
+   # Option A: write bom.json alongside your working copy so follow-up scans can find it
+   cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom.json --output "$(pwd)"
+
+   # Option B: rely on the default output directory and reference it explicitly later
    cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom.json
    ```
 
-4. **Scan the SBOM with Grype**:
+4. **Scan the SBOM with Grype** (pointing at whichever location you chose above):
    ```bash
    grype sbom:./bom.json
+   # or
+   grype sbom:target/cyclonedx/bom.json
    ```
 
 5. (Optional) Export detailed findings:

--- a/README.md
+++ b/README.md
@@ -56,17 +56,15 @@ ty guide referenced in this task.
    ```
    Refer to the [Grype README](https://github.com/anchore/grype) for macOS and Windows alternatives.
 
-3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled. The command writes to Cargo's default `target/cyclonedx` folder; copy it beside your working tree if that's more convenient for follow-up tooling:
+3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled. Overriding the filename causes `cargo-cyclonedx` to place the SBOM in the current working directory, making it easy to move or archive:
    ```bash
-   cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom.json
-   cp target/cyclonedx/bom.json ./bom.json  # optional convenience copy
+   cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom
+   # cargo-cyclonedx writes bom.json into the current working directory; move it if you prefer a different location
    ```
 
 4. **Scan the SBOM with Grype** (pointing at whichever location you chose above):
    ```bash
    grype sbom:./bom.json
-   # or
-   grype sbom:target/cyclonedx/bom.json
    ```
 
 5. (Optional) Export detailed findings:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,41 @@ cargo fmt --all
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
+### Supply Chain Security
+
+ShadowMap includes a lightweight workflow for generating a Software Bill of Materials (SBOM) and scanning it for known vulnerab
+ilities. The steps below follow the [cargo-cyclonedx + Grype quickstart](https://gitlab.com/-/snippets/4892073) from the securi
+ty guide referenced in this task.
+
+1. **Install cargo-cyclonedx** (once per machine):
+   ```bash
+   cargo install cargo-cyclonedx
+   ```
+
+2. **Install Grype** (Linux/WSL example):
+   ```bash
+   curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
+   ```
+   Refer to the [Grype README](https://github.com/anchore/grype) for macOS and Windows alternatives.
+
+3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled:
+   ```bash
+   cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom.json
+   ```
+
+4. **Scan the SBOM with Grype**:
+   ```bash
+   grype sbom:./bom.json
+   ```
+
+5. (Optional) Export detailed findings:
+   ```bash
+   grype sbom:./bom.json -o json --file vulnerability-report.json
+   ```
+
+For repeatability you can run `./scripts/security-scan.sh` which wraps the SBOM generation and Grype scan with sensible default
+s.
+
 ### Desktop GUI (optional)
 ```bash
 cargo run --features gui --bin shadowmap-gui

--- a/README.md
+++ b/README.md
@@ -56,13 +56,10 @@ ty guide referenced in this task.
    ```
    Refer to the [Grype README](https://github.com/anchore/grype) for macOS and Windows alternatives.
 
-3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled. Either emit the file to the current directory or read it from Cargo's default `target/cyclonedx` folder:
+3. **Generate the SBOM** in CycloneDX JSON format with all ShadowMap features enabled. The command writes to Cargo's default `target/cyclonedx` folder; copy it beside your working tree if that's more convenient for follow-up tooling:
    ```bash
-   # Option A: write bom.json alongside your working copy so follow-up scans can find it
-   cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom.json --output "$(pwd)"
-
-   # Option B: rely on the default output directory and reference it explicitly later
    cargo cyclonedx --format json --spec-version 1.5 --all-features --override-filename bom.json
+   cp target/cyclonedx/bom.json ./bom.json  # optional convenience copy
    ```
 
 4. **Scan the SBOM with Grype** (pointing at whichever location you chose above):

--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ ty guide referenced in this task.
    grype sbom:./bom.json -o json --file vulnerability-report.json
    ```
 
-For repeatability you can run `./scripts/security-scan.sh` which wraps the SBOM generation and Grype scan with sensible default
-s.
+For repeatability you can run `./scripts/security-scan.sh` which wraps the SBOM generation and Grype scan with sensible defaults.
+
+### Automated security workflow
+
+The repository ships with a dedicated GitHub Action located at [`.github/workflows/security-scan.yml`](.github/workflows/security-scan.yml). It installs `cargo-cyclonedx` and `grype`, generates `shadowmap-bom.json`, scans it for vulnerabilities, and uploads the SBOM plus a JSON report as build artifacts. The workflow runs automatically for pull requests and pushes to `main`, and can also be started manually from the **Actions** tab via the **Run workflow** button.
 
 ### Desktop GUI (optional)
 ```bash

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOM_FILENAME="${1:-bom.json}"
+REPORT_FILENAME="${2:-}" # optional second arg for JSON report
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+if ! command_exists cargo; then
+  echo "cargo is required to generate the SBOM." >&2
+  exit 1
+fi
+
+if ! cargo cyclonedx --version >/dev/null 2>&1; then
+  cat <<'MSG' >&2
+cargo-cyclonedx is not installed.
+Install it with: cargo install cargo-cyclonedx
+MSG
+  exit 1
+fi
+
+if ! command_exists grype; then
+  cat <<'MSG' >&2
+grype is not installed.
+Install it with: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
+MSG
+  exit 1
+fi
+
+# Generate SBOM
+cargo cyclonedx \
+  --format json \
+  --spec-version 1.5 \
+  --all-features \
+  --override-filename "$BOM_FILENAME"
+
+echo "Generated SBOM at $BOM_FILENAME"
+
+# Scan SBOM with Grype
+if [[ -n "$REPORT_FILENAME" ]]; then
+  grype "sbom:./$BOM_FILENAME" -o json --file "$REPORT_FILENAME"
+  echo "Stored vulnerability report at $REPORT_FILENAME"
+else
+  grype "sbom:./$BOM_FILENAME"
+fi
+

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -29,20 +29,27 @@ MSG
   exit 1
 fi
 
-# Generate SBOM
+# Generate SBOM where the caller expects it so the subsequent Grype call can find it
+BOM_PATH="$PWD/$BOM_FILENAME"
+BOM_DIR="$(dirname "$BOM_PATH")"
+BOM_BASENAME="$(basename "$BOM_PATH")"
+
+mkdir -p "$BOM_DIR"
+
 cargo cyclonedx \
   --format json \
   --spec-version 1.5 \
   --all-features \
-  --override-filename "$BOM_FILENAME"
+  --override-filename "$BOM_BASENAME" \
+  --output "$BOM_DIR"
 
-echo "Generated SBOM at $BOM_FILENAME"
+echo "Generated SBOM at $BOM_PATH"
 
 # Scan SBOM with Grype
 if [[ -n "$REPORT_FILENAME" ]]; then
-  grype "sbom:./$BOM_FILENAME" -o json --file "$REPORT_FILENAME"
+  grype "sbom:$BOM_PATH" -o json --file "$REPORT_FILENAME"
   echo "Stored vulnerability report at $REPORT_FILENAME"
 else
-  grype "sbom:./$BOM_FILENAME"
+  grype "sbom:$BOM_PATH"
 fi
 


### PR DESCRIPTION
## Summary
- document the cargo-cyclonedx and Grype workflow for SBOM generation and scanning
- add a helper script to automate SBOM creation and vulnerability scanning

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68d7e3b3ef688326bcb2869db321e716