### PR TITLE
[shadowmap] fix: reinforce agent retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ShadowMap is a Rust framework for disciplined subdomain enumeration, vulnerabili
 - **Performance-first engine**: Async Rust core with configurable concurrency to cover large scopes quickly.
 - **Actionable exports**: Ships clean CSV, JSON, and TXT outputs for reporting or downstream automation.
 - **Extensible recon modules**: Plug-in architecture for port scanning, fingerprinting, and cloud exposure checks.
+- **Rig-style autonomy**: Optional agent orchestrator that sequences every recon module, retries failures, and flags deep cloud assets automatically.
 
 ---
 
@@ -102,6 +103,12 @@ Pipe JSON output for downstream automation:
 ```bash
 shadowmap -d target.com --json > report.json
 ```
+
+Enable the autonomous Rig-inspired orchestrator with deep cloud discovery:
+```bash
+shadowmap -d target.com --autonomous
+```
+The agent executes each reconnaissance stage with retry-aware control flow, surfaces SaaS predictors, and produces `cloud_assets.json` alongside traditional reports for deep storage/bucket exposure review.
 
 ---
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,528 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::anyhow;
+use chrono::Local;
+use idna::domain_to_unicode;
+use reqwest::{redirect::Policy, Client};
+use tokio::time::Duration;
+
+use crate::cloud::{cloud_saas_recon, deep_cloud_asset_discovery, CloudAssetFinding};
+use crate::constants::{IP_REGEX, SUBDOMAIN_REGEX};
+use crate::cors::check_cors;
+use crate::dns::{check_dns_live, create_secure_resolver};
+use crate::enumeration::crtsh_enum_async;
+use crate::fingerprint::fingerprint_software;
+use crate::headers::check_headers_tls;
+use crate::ports::scan_ports;
+use crate::takeover::check_subdomain_takeover;
+use crate::Args;
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[derive(Clone, Debug)]
+pub struct EnumerationResult {
+    pub discovered: Vec<String>,
+    pub validated: HashSet<String>,
+}
+
+#[derive(Debug, Default)]
+struct AgentExecutionState {
+    enumeration: Option<EnumerationResult>,
+    live_subdomains: Option<HashSet<String>>,
+    open_ports_map: Option<HashMap<String, Vec<u16>>>,
+    header_map: Option<HashMap<String, (u16, Option<String>)>>,
+    cors_map: Option<HashMap<String, Vec<String>>>,
+    software_map: Option<HashMap<String, HashMap<String, String>>>,
+    takeover_map: Option<HashMap<String, Vec<String>>>,
+    cloud_saas_map: Option<HashMap<String, Vec<String>>>,
+    cloud_asset_map: Option<HashMap<String, Vec<CloudAssetFinding>>>,
+}
+
+pub struct ReconEngine {
+    args: Args,
+    client: Client,
+    output_dir: String,
+}
+
+impl ReconEngine {
+    pub async fn bootstrap(args: Args) -> Result<Self, BoxError> {
+        let timestamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
+        let output_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("recon_results")
+            .join(format!("{}_{}", args.domain, timestamp));
+        std::fs::create_dir_all(&output_dir)?;
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(args.timeout))
+            .redirect(Policy::limited(2))
+            .danger_accept_invalid_certs(false)
+            .pool_idle_timeout(Some(Duration::from_secs(30)))
+            .build()?;
+
+        Ok(Self {
+            args,
+            client,
+            output_dir: output_dir.to_string_lossy().to_string(),
+        })
+    }
+
+    pub fn is_autonomous(&self) -> bool {
+        self.args.autonomous
+    }
+
+    pub fn log_run_banner(&self) {
+        eprintln!(
+            "[*] Starting security-enhanced recon for *.{}",
+            self.args.domain
+        );
+        eprintln!("[*] Configuration:");
+        eprintln!("    - Domain: {}", self.args.domain);
+        eprintln!("    - Concurrency: {}", self.args.concurrency);
+        eprintln!("    - Timeout: {}s", self.args.timeout);
+        eprintln!("    - Retries: {}", self.args.retries);
+        eprintln!("    - Output: {}", self.output_dir);
+        if self.is_autonomous() {
+            eprintln!("    - Orchestration: autonomous agent (Rig-style)");
+        }
+    }
+
+    pub fn domain(&self) -> &str {
+        &self.args.domain
+    }
+
+    pub fn output_dir(&self) -> &str {
+        &self.output_dir
+    }
+
+    pub fn request_timeout(&self) -> Duration {
+        Duration::from_secs(self.args.timeout)
+    }
+
+    pub fn concurrency(&self) -> usize {
+        self.args.concurrency
+    }
+
+    pub fn retries(&self) -> usize {
+        self.args.retries.max(1)
+    }
+
+    pub async fn enumerate_subdomains(&self) -> Result<EnumerationResult, BoxError> {
+        let raw_subdomains =
+            crtsh_enum_async(&self.client, &self.args.domain, self.args.retries).await?;
+
+        let mut discovered: Vec<String> = raw_subdomains.iter().cloned().collect();
+        discovered.sort();
+
+        let validated: HashSet<String> = discovered
+            .iter()
+            .filter_map(|raw| {
+                let s = raw.replace("*.", "").replace("www.", "");
+                let (decoded, result) = domain_to_unicode(&s);
+                if result.is_err() {
+                    return None;
+                }
+                let s_lower = decoded.to_lowercase();
+
+                if IP_REGEX.is_match(&s_lower) || !SUBDOMAIN_REGEX.is_match(&s_lower) {
+                    return None;
+                }
+
+                if s_lower.ends_with(&format!(".{}", self.args.domain))
+                    || s_lower == self.args.domain
+                {
+                    Some(s_lower)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Ok(EnumerationResult {
+            discovered,
+            validated,
+        })
+    }
+
+    pub async fn resolve_live_subdomains(
+        &self,
+        validated: &HashSet<String>,
+    ) -> Result<HashSet<String>, BoxError> {
+        let resolver = create_secure_resolver().await?;
+        Ok(check_dns_live(validated, resolver, self.args.concurrency).await)
+    }
+
+    pub async fn scan_open_ports(&self, subs: &HashSet<String>) -> HashMap<String, Vec<u16>> {
+        scan_ports(subs, self.args.concurrency).await
+    }
+
+    pub async fn inspect_headers(
+        &self,
+        subs: &HashSet<String>,
+    ) -> HashMap<String, (u16, Option<String>)> {
+        check_headers_tls(&self.client, subs, self.args.concurrency, self.args.timeout).await
+    }
+
+    pub async fn inspect_cors(&self, subs: &HashSet<String>) -> HashMap<String, Vec<String>> {
+        check_cors(&self.client, subs, self.args.concurrency, self.args.timeout).await
+    }
+
+    pub async fn fingerprint_software(
+        &self,
+        subs: &HashSet<String>,
+    ) -> HashMap<String, HashMap<String, String>> {
+        fingerprint_software(&self.client, subs, self.args.concurrency, self.args.timeout).await
+    }
+
+    pub async fn discover_cloud_saas(
+        &self,
+        subs: &HashSet<String>,
+    ) -> Result<HashMap<String, Vec<String>>, BoxError> {
+        let resolver_for_cloud = create_secure_resolver().await?;
+        Ok(cloud_saas_recon(subs, resolver_for_cloud, self.args.concurrency).await)
+    }
+
+    pub async fn discover_cloud_assets(
+        &self,
+        subs: &HashSet<String>,
+    ) -> HashMap<String, Vec<CloudAssetFinding>> {
+        deep_cloud_asset_discovery(
+            subs,
+            &self.client,
+            self.args.concurrency,
+            self.request_timeout(),
+        )
+        .await
+    }
+
+    pub async fn detect_takeovers(&self, subs: &HashSet<String>) -> HashMap<String, Vec<String>> {
+        check_subdomain_takeover(subs).await
+    }
+
+    pub async fn execute_full_scan(self) -> Result<ReconReport, BoxError> {
+        let enumeration = self.enumerate_subdomains().await?;
+        eprintln!(
+            "[+] crt.sh found {} potential subdomains",
+            enumeration.discovered.len()
+        );
+        eprintln!("[+] Validated {} subdomains", enumeration.validated.len());
+
+        let live_subs = self.resolve_live_subdomains(&enumeration.validated).await?;
+        eprintln!("[+] {} live subdomains detected", live_subs.len());
+
+        let open_ports_map = self.scan_open_ports(&live_subs).await;
+        eprintln!(
+            "[+] Port scan complete - found {} subdomains with open ports",
+            open_ports_map.len()
+        );
+
+        let header_map = self.inspect_headers(&live_subs).await;
+        eprintln!("[+] Header/TLS check complete");
+
+        let cors_map = self.inspect_cors(&live_subs).await;
+        eprintln!(
+            "[+] CORS check complete - found {} potential issues",
+            cors_map.len()
+        );
+
+        let software_map = self.fingerprint_software(&live_subs).await;
+        eprintln!("[+] Software fingerprinting complete");
+
+        let cloud_saas_map = self.discover_cloud_saas(&live_subs).await?;
+        eprintln!(
+            "[+] Cloud/SaaS reconnaissance complete - found {} subdomains with SaaS patterns or predictions",
+            cloud_saas_map.len()
+        );
+
+        let cloud_asset_map = self.discover_cloud_assets(&live_subs).await;
+        eprintln!(
+            "[+] Deep cloud asset discovery complete - flagged {} subdomains",
+            cloud_asset_map.len()
+        );
+
+        let takeover_map = self.detect_takeovers(&live_subs).await;
+        eprintln!(
+            "[+] Takeover check complete - found {} potential targets (including cloud)",
+            takeover_map.len()
+        );
+
+        Ok(ReconReport {
+            domain: self.args.domain,
+            output_dir: self.output_dir,
+            discovered_subdomains: enumeration.discovered,
+            validated_subdomains: enumeration.validated,
+            live_subdomains: live_subs,
+            open_ports_map,
+            header_map,
+            cors_map,
+            software_map,
+            takeover_map,
+            cloud_saas_map,
+            cloud_asset_map,
+        })
+    }
+}
+
+pub struct AutonomousReconAgent {
+    engine: ReconEngine,
+    step_retries: usize,
+}
+
+impl AutonomousReconAgent {
+    pub fn new(engine: ReconEngine) -> Self {
+        let step_retries = engine.retries();
+        Self {
+            engine,
+            step_retries,
+        }
+    }
+
+    pub async fn execute(self) -> Result<ReconReport, BoxError> {
+        let AutonomousReconAgent {
+            engine,
+            step_retries,
+        } = self;
+
+        let mut state = AgentExecutionState::default();
+        for step in plan(step_retries) {
+            eprintln!("[agent] ➡️ {}", step.name);
+
+            let mut attempt = 0usize;
+            loop {
+                attempt += 1;
+                let step_result = match step.kind {
+                    StepKind::Enumerate => match engine.enumerate_subdomains().await {
+                        Ok(enumeration) => {
+                            eprintln!(
+                                "[agent]    discovered {} candidates, {} survived validation",
+                                enumeration.discovered.len(),
+                                enumeration.validated.len()
+                            );
+                            state.enumeration = Some(enumeration);
+                            Ok(())
+                        }
+                        Err(err) => Err(err),
+                    },
+                    StepKind::Resolve => {
+                        if let Some(enumeration) = state.enumeration.as_ref() {
+                            match engine.resolve_live_subdomains(&enumeration.validated).await {
+                                Ok(live) => {
+                                    eprintln!(
+                                        "[agent]    {} live subdomains after DNS validation",
+                                        live.len()
+                                    );
+                                    state.live_subdomains = Some(live);
+                                    Ok(())
+                                }
+                                Err(err) => Err(err),
+                            }
+                        } else {
+                            Err(missing_step_error("enumeration step missing"))
+                        }
+                    }
+                    StepKind::Ports => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            let ports = engine.scan_open_ports(live).await;
+                            eprintln!("[agent]    {} subdomains expose open ports", ports.len());
+                            state.open_ports_map = Some(ports);
+                            Ok(())
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                    StepKind::Headers => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            let headers = engine.inspect_headers(live).await;
+                            state.header_map = Some(headers);
+                            Ok(())
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                    StepKind::Cors => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            let cors = engine.inspect_cors(live).await;
+                            eprintln!("[agent]    CORS anomalies flagged on {} hosts", cors.len());
+                            state.cors_map = Some(cors);
+                            Ok(())
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                    StepKind::Fingerprint => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            let fingerprints = engine.fingerprint_software(live).await;
+                            state.software_map = Some(fingerprints);
+                            Ok(())
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                    StepKind::CloudSaas => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            match engine.discover_cloud_saas(live).await {
+                                Ok(saas) => {
+                                    eprintln!(
+                                        "[agent]    {} SaaS indicators identified",
+                                        saas.len()
+                                    );
+                                    state.cloud_saas_map = Some(saas);
+                                    Ok(())
+                                }
+                                Err(err) => Err(err),
+                            }
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                    StepKind::CloudAssets => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            let assets = engine.discover_cloud_assets(live).await;
+                            eprintln!("[agent]    {} cloud assets worth review", assets.len());
+                            state.cloud_asset_map = Some(assets);
+                            Ok(())
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                    StepKind::Takeover => {
+                        if let Some(live) = state.live_subdomains.as_ref() {
+                            let takeover = engine.detect_takeovers(live).await;
+                            eprintln!("[agent]    {} takeover candidates queued", takeover.len());
+                            state.takeover_map = Some(takeover);
+                            Ok(())
+                        } else {
+                            Err(missing_step_error("live subdomains missing"))
+                        }
+                    }
+                };
+
+                match step_result {
+                    Ok(_) => {
+                        if attempt > 1 {
+                            eprintln!("[agent]    recovered after {} attempts", attempt);
+                        }
+                        break;
+                    }
+                    Err(err) => {
+                        if attempt >= step.max_attempts {
+                            return Err(err);
+                        }
+                        eprintln!(
+                            "[agent]    attempt {} failed ({}), retrying...",
+                            attempt, err
+                        );
+                    }
+                }
+            }
+        }
+
+        let enumeration = state
+            .enumeration
+            .ok_or_else(|| missing_step_error("enumeration missing"))?;
+        let live_subdomains = state
+            .live_subdomains
+            .ok_or_else(|| missing_step_error("live subdomains missing"))?;
+
+        let ReconEngine {
+            args,
+            client: _,
+            output_dir,
+        } = engine;
+        let Args { domain, .. } = args;
+
+        Ok(ReconReport {
+            domain,
+            output_dir,
+            discovered_subdomains: enumeration.discovered,
+            validated_subdomains: enumeration.validated,
+            live_subdomains,
+            open_ports_map: state.open_ports_map.unwrap_or_default(),
+            header_map: state.header_map.unwrap_or_default(),
+            cors_map: state.cors_map.unwrap_or_default(),
+            software_map: state.software_map.unwrap_or_default(),
+            takeover_map: state.takeover_map.unwrap_or_default(),
+            cloud_saas_map: state.cloud_saas_map.unwrap_or_default(),
+            cloud_asset_map: state.cloud_asset_map.unwrap_or_default(),
+        })
+    }
+}
+
+fn plan(step_retries: usize) -> Vec<AgentStep> {
+    let max_attempts = step_retries.max(1);
+    vec![
+        AgentStep::new(
+            "Enumerate subdomains via CRT.sh",
+            StepKind::Enumerate,
+            max_attempts,
+        ),
+        AgentStep::new("Validate DNS responses", StepKind::Resolve, max_attempts),
+        AgentStep::new("Port scan live assets", StepKind::Ports, max_attempts),
+        AgentStep::new("Capture headers & TLS", StepKind::Headers, max_attempts),
+        AgentStep::new("Analyse CORS controls", StepKind::Cors, max_attempts),
+        AgentStep::new(
+            "Fingerprint running software",
+            StepKind::Fingerprint,
+            max_attempts,
+        ),
+        AgentStep::new(
+            "Predict SaaS/cloud usage",
+            StepKind::CloudSaas,
+            max_attempts,
+        ),
+        AgentStep::new(
+            "Discover deep cloud assets",
+            StepKind::CloudAssets,
+            max_attempts,
+        ),
+        AgentStep::new("Assess takeover exposure", StepKind::Takeover, max_attempts),
+    ]
+}
+
+struct AgentStep {
+    name: &'static str,
+    kind: StepKind,
+    max_attempts: usize,
+}
+
+impl AgentStep {
+    fn new(name: &'static str, kind: StepKind, max_attempts: usize) -> Self {
+        Self {
+            name,
+            kind,
+            max_attempts,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+enum StepKind {
+    Enumerate,
+    Resolve,
+    Ports,
+    Headers,
+    Cors,
+    Fingerprint,
+    CloudSaas,
+    CloudAssets,
+    Takeover,
+}
+
+pub struct ReconReport {
+    pub domain: String,
+    pub output_dir: String,
+    pub discovered_subdomains: Vec<String>,
+    pub validated_subdomains: HashSet<String>,
+    pub live_subdomains: HashSet<String>,
+    pub open_ports_map: HashMap<String, Vec<u16>>,
+    pub header_map: HashMap<String, (u16, Option<String>)>,
+    pub cors_map: HashMap<String, Vec<String>>,
+    pub software_map: HashMap<String, HashMap<String, String>>,
+    pub takeover_map: HashMap<String, Vec<String>>,
+    pub cloud_saas_map: HashMap<String, Vec<String>>,
+    pub cloud_asset_map: HashMap<String, Vec<CloudAssetFinding>>,
+}
+
+fn missing_step_error(message: &str) -> BoxError {
+    anyhow!(message.to_string()).into()
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,4 +18,8 @@ pub struct Args {
     /// Number of retries for failed requests
     #[arg(short, long, default_value = "3")]
     pub retries: usize,
+
+    /// Enable the autonomous Rig-inspired orchestration engine
+    #[arg(long, default_value_t = false)]
+    pub autonomous: bool,
 }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -2,11 +2,47 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::stream::{FuturesUnordered, StreamExt};
+use reqwest::Client;
+use serde::Serialize;
 use tokio::sync::Semaphore;
-use tokio::time::timeout;
+use tokio::time::{timeout, Duration};
 use trust_dns_resolver::TokioAsyncResolver;
 
 use crate::constants::{CLOUD_SAAS_PATTERNS, DNS_TIMEOUT};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudAssetStatus {
+    Accessible,
+    Forbidden,
+    ExistsNoAccess,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CloudAssetFinding {
+    pub provider: String,
+    pub asset: String,
+    pub status: CloudAssetStatus,
+    pub notes: Option<String>,
+}
+
+impl CloudAssetStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CloudAssetStatus::Accessible => "accessible",
+            CloudAssetStatus::Forbidden => "forbidden",
+            CloudAssetStatus::ExistsNoAccess => "exists_no_access",
+            CloudAssetStatus::Unknown => "unknown",
+        }
+    }
+}
+
+impl CloudAssetFinding {
+    pub fn status_string(&self) -> &'static str {
+        self.status.as_str()
+    }
+}
 
 pub async fn cloud_saas_recon(
     subs: &std::collections::HashSet<String>,
@@ -70,4 +106,149 @@ pub async fn cloud_saas_recon(
     }
 
     results
+}
+
+pub async fn deep_cloud_asset_discovery(
+    subs: &std::collections::HashSet<String>,
+    client: &Client,
+    max_concurrency: usize,
+    per_asset_timeout: Duration,
+) -> HashMap<String, Vec<CloudAssetFinding>> {
+    let semaphore = Arc::new(Semaphore::new(max_concurrency));
+    let mut tasks = FuturesUnordered::new();
+
+    for sub in subs.iter() {
+        let sub = sub.clone();
+        let semaphore = Arc::clone(&semaphore);
+        let client = client.clone();
+
+        tasks.push(tokio::spawn(async move {
+            let _permit = semaphore
+                .acquire()
+                .await
+                .expect("Semaphore unexpectedly closed");
+
+            let mut findings = Vec::new();
+            let candidates = candidate_cloud_assets(&sub);
+
+            for (provider, asset) in candidates {
+                let request = client.head(&asset);
+                match timeout(per_asset_timeout, request.send()).await {
+                    Ok(Ok(resp)) => {
+                        let status = resp.status();
+                        let (finding_status, notes) = match status.as_u16() {
+                            200..=299 => (
+                                CloudAssetStatus::Accessible,
+                                Some(format!("HTTP {}", status)),
+                            ),
+                            401..=403 => (
+                                CloudAssetStatus::ExistsNoAccess,
+                                Some(format!("Restricted access ({})", status)),
+                            ),
+                            404 => continue,
+                            429 => (
+                                CloudAssetStatus::Forbidden,
+                                Some("Rate limited when probing asset".to_string()),
+                            ),
+                            _ => (
+                                CloudAssetStatus::Unknown,
+                                Some(format!("Unexpected status {}", status)),
+                            ),
+                        };
+
+                        if !matches!(finding_status, CloudAssetStatus::Unknown) {
+                            findings.push(CloudAssetFinding {
+                                provider: provider.clone(),
+                                asset,
+                                status: finding_status,
+                                notes: notes.clone(),
+                            });
+                        }
+                    }
+                    Ok(Err(err)) => {
+                        let message = err.to_string();
+                        if message.contains("dns") || message.contains("No such host") {
+                            continue;
+                        }
+                        findings.push(CloudAssetFinding {
+                            provider: provider.clone(),
+                            asset,
+                            status: CloudAssetStatus::Unknown,
+                            notes: Some(message),
+                        });
+                    }
+                    Err(_) => {
+                        findings.push(CloudAssetFinding {
+                            provider: provider.clone(),
+                            asset,
+                            status: CloudAssetStatus::Unknown,
+                            notes: Some("Timed out probing asset".to_string()),
+                        });
+                    }
+                }
+            }
+
+            if findings.is_empty() {
+                None
+            } else {
+                Some((sub, findings))
+            }
+        }));
+    }
+
+    let mut results = HashMap::new();
+    while let Some(res) = tasks.next().await {
+        if let Ok(Some((sub, findings))) = res {
+            results.insert(sub, findings);
+        }
+    }
+
+    results
+}
+
+fn candidate_cloud_assets(sub: &str) -> Vec<(String, String)> {
+    let dashed = sub.replace('.', "-");
+
+    vec![
+        (
+            "aws_s3".to_string(),
+            format!("https://{}.s3.amazonaws.com", sub),
+        ),
+        (
+            "aws_s3".to_string(),
+            format!("https://{}.s3.amazonaws.com", dashed),
+        ),
+        (
+            "aws_cloudfront".to_string(),
+            format!("https://{}.cloudfront.net", dashed),
+        ),
+        (
+            "azure_blob".to_string(),
+            format!("https://{}.blob.core.windows.net", sub),
+        ),
+        (
+            "azure_static_web".to_string(),
+            format!("https://{}.azurestaticapps.net", dashed),
+        ),
+        (
+            "gcp_storage".to_string(),
+            format!("https://{}.storage.googleapis.com", sub),
+        ),
+        (
+            "gcp_storage".to_string(),
+            format!("https://storage.googleapis.com/{}", sub),
+        ),
+        (
+            "digitalocean_spaces".to_string(),
+            format!("https://{}.digitaloceanspaces.com", sub),
+        ),
+        (
+            "cloudflare_r2".to_string(),
+            format!("https://{}.r2.cloudflarestorage.com", sub),
+        ),
+        (
+            "wasabi".to_string(),
+            format!("https://{}.wasabisys.com", sub),
+        ),
+    ]
 }

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -189,6 +189,7 @@ impl ShadowMapApp {
             concurrency: self.config.concurrency,
             timeout: self.config.timeout,
             retries: self.config.retries,
+            autonomous: false,
         };
 
         Command::perform(run_scan(args), Message::ScanFinished)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod agent;
 pub mod args;
 mod cloud;
 mod constants;
@@ -10,125 +11,43 @@ mod ports;
 mod reporting;
 mod takeover;
 
+pub use agent::BoxError;
+pub use agent::{AutonomousReconAgent, ReconEngine, ReconReport};
 pub use args::Args;
-
-use chrono::Local;
-use idna::domain_to_unicode;
-use reqwest::{redirect::Policy, Client};
-use std::collections::HashSet;
-use tokio::time::Duration;
-
-use cloud::cloud_saas_recon;
-use constants::{IP_REGEX, SUBDOMAIN_REGEX};
-use cors::check_cors;
-use dns::{check_dns_live, create_secure_resolver};
-use enumeration::crtsh_enum_async;
-use fingerprint::fingerprint_software;
-use headers::check_headers_tls;
-use ports::scan_ports;
 use reporting::{write_outputs, ReconMaps};
-use std::path::Path;
-use takeover::check_subdomain_takeover;
 
-pub async fn run(args: Args) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    let timestamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
-    let output_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("recon_results")
-        .join(format!("{}_{}", args.domain, timestamp));
-    std::fs::create_dir_all(&output_dir)?;
-    let output_dir = output_dir.to_string_lossy().to_string();
+pub async fn run(args: Args) -> Result<String, BoxError> {
+    let engine = ReconEngine::bootstrap(args).await?;
+    engine.log_run_banner();
+    let use_agent = engine.is_autonomous();
 
-    eprintln!("[*] Starting security-enhanced recon for *.{}", args.domain);
-    eprintln!("[*] Configuration:");
-    eprintln!("    - Domain: {}", args.domain);
-    eprintln!("    - Concurrency: {}", args.concurrency);
-    eprintln!("    - Timeout: {}s", args.timeout);
-    eprintln!("    - Retries: {}", args.retries);
-    eprintln!("    - Output: {}", output_dir);
-
-    let client = Client::builder()
-        .timeout(Duration::from_secs(args.timeout))
-        .redirect(Policy::limited(2))
-        .danger_accept_invalid_certs(false)
-        .pool_idle_timeout(Some(Duration::from_secs(30)))
-        .build()?;
-
-    let crt_subs = crtsh_enum_async(&client, &args.domain, args.retries).await?;
-    eprintln!("[+] crt.sh found {} potential subdomains", crt_subs.len());
-
-    let validated_subs: HashSet<String> = crt_subs
-        .into_iter()
-        .filter_map(|s| {
-            let s = s.replace("*.", "").replace("www.", "");
-            let (decoded, result) = domain_to_unicode(&s);
-            if result.is_err() {
-                return None;
-            }
-            let s_lower = decoded.to_lowercase();
-
-            if IP_REGEX.is_match(&s_lower) || !SUBDOMAIN_REGEX.is_match(&s_lower) {
-                return None;
-            }
-
-            if s_lower.ends_with(&format!(".{}", args.domain)) || s_lower == args.domain {
-                Some(s_lower)
-            } else {
-                None
-            }
-        })
-        .collect();
-    eprintln!("[+] Validated {} subdomains", validated_subs.len());
-
-    let resolver = create_secure_resolver().await?;
-    let live_subs = check_dns_live(&validated_subs, resolver, args.concurrency).await;
-    eprintln!("[+] {} live subdomains detected", live_subs.len());
-
-    let open_ports_map = scan_ports(&live_subs, args.concurrency).await;
-    eprintln!(
-        "[+] Port scan complete - found {} subdomains with open ports",
-        open_ports_map.len()
-    );
-
-    let header_map = check_headers_tls(&client, &live_subs, args.concurrency, args.timeout).await;
-    eprintln!("[+] Header/TLS check complete");
-
-    let cors_map = check_cors(&client, &live_subs, args.concurrency, args.timeout).await;
-    eprintln!(
-        "[+] CORS check complete - found {} potential issues",
-        cors_map.len()
-    );
-
-    let software_map =
-        fingerprint_software(&client, &live_subs, args.concurrency, args.timeout).await;
-    eprintln!("[+] Software fingerprinting complete");
-
-    let resolver_for_cloud = create_secure_resolver().await?;
-    let cloud_saas_map = cloud_saas_recon(&live_subs, resolver_for_cloud, args.concurrency).await;
-    eprintln!(
-        "[+] Cloud/SaaS reconnaissance complete - found {} subdomains with SaaS patterns or predictions",
-        cloud_saas_map.len()
-    );
-
-    let takeover_map = check_subdomain_takeover(&live_subs).await;
-    eprintln!(
-        "[+] Takeover check complete - found {} potential targets (including cloud)",
-        takeover_map.len()
-    );
+    let report = if use_agent {
+        AutonomousReconAgent::new(engine).execute().await?
+    } else {
+        engine.execute_full_scan().await?
+    };
 
     write_outputs(
-        &live_subs,
+        &report.live_subdomains,
         ReconMaps {
-            header_map: &header_map,
-            open_ports_map: &open_ports_map,
-            cors_map: &cors_map,
-            software_map: &software_map,
-            takeover_map: &takeover_map,
-            cloud_saas_map: &cloud_saas_map,
+            header_map: &report.header_map,
+            open_ports_map: &report.open_ports_map,
+            cors_map: &report.cors_map,
+            software_map: &report.software_map,
+            takeover_map: &report.takeover_map,
+            cloud_saas_map: &report.cloud_saas_map,
+            cloud_asset_map: &report.cloud_asset_map,
         },
-        &output_dir,
-        &args.domain,
+        &report.output_dir,
+        &report.domain,
     )?;
 
-    eprintln!("[*] Recon complete. Outputs in: {}", output_dir);
-    Ok(output_dir)
+    eprintln!(
+        "[*] Recon complete. Outputs in: {} ({} live, {} deep cloud alerts)",
+        report.output_dir,
+        report.live_subdomains.len(),
+        report.cloud_asset_map.len()
+    );
+
+    Ok(report.output_dir)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -142,6 +142,7 @@ async fn run_job(state: AppState, job_id: JobId, domain: String, config: JobConf
         concurrency: config.concurrency,
         timeout: config.timeout,
         retries: config.retries,
+        autonomous: false,
     };
     match run(args).await {
         Ok(path) => {


### PR DESCRIPTION
## Summary
- add a Rig-inspired autonomous recon agent and engine abstraction to orchestrate the existing modules
- expand cloud reconnaissance with deep asset discovery and persist findings into CSV/JSON reports
- document the new --autonomous flag while keeping GUI and server runs on the classic flow by default
- ensure the autonomous step loop bubbles transient failures to the retry handler and clean up HTTP status matching

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68da303927308326a1c6cf9b6db2f3dc