### PR TITLE
[docs] docs: add organizational adoption playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ ShadowMap aligns its operational safeguards with SOC 2 Trust Services Criteria a
 [Data Security and Compliance Strategy](docs/data-security.md) describes the control owners, evidence expectations, and
 validation activities that keep reconnaissance data secure throughout its lifecycle.
 
+### Organizational Adoption Playbook
+
+Security programs that want to operationalize ShadowMap across large enterprises can follow the
+[Organizational Adoption Playbook](docs/org-adaptation.md). It lays out governance structures, stakeholder roles, and
+business metrics that translate reconnaissance coverage into measurable risk reduction and executive-aligned value.
+
 ### Automated security workflow
 
 The repository ships with a dedicated GitHub Action located at [`.github/workflows/security-scan.yml`](.github/workflows/security-scan.yml). It installs `cargo-cyclonedx` and `grype`, generates `shadowmap-bom.json`, scans it for vulnerabilities, and uploads the SBOM plus a JSON report as build artifacts. The workflow runs automatically for pull requests and pushes to `main`, and can also be started manually from the **Actions** tab via the **Run workflow** button.

--- a/docs/org-adaptation.md
+++ b/docs/org-adaptation.md
@@ -1,0 +1,98 @@
+# ShadowMap Organizational Adoption Playbook
+
+## Executive Summary
+ShadowMap augments security and threat-intelligence teams with disciplined, scalable reconnaissance. Organizations that weave it into their operating model can close exposure gaps faster, elevate collaboration between security and business teams, and deliver defensible reporting to regulators and customers. This playbook outlines the decisions, structures, and success metrics that accelerate adoption while keeping risk management grounded in measurable business impact.
+
+## Strategic Outcomes to Target
+1. **Attack surface visibility as a managed service** – Convert ad-hoc recon into a governed program with service-level objectives for discovery freshness and mean-time-to-remediate exposures.
+2. **Revenue-aligned risk prioritization** – Map discovered assets to revenue streams or customer-impact tiers so remediation work queues align with business value.
+3. **Audit-ready evidence** – Produce standardized SBOMs, vulnerability reports, and remediation audit trails that satisfy SOC 2, ISO 27001, and customer security questionnaires.
+4. **Operational leverage** – Automate repetitive reconnaissance, freeing analysts to investigate high-signal findings and collaborate with product and infrastructure teams.
+
+## Stakeholder Alignment Framework
+| Stakeholder | Primary Motivation | Required Contribution | Key Message |
+|-------------|-------------------|------------------------|-------------|
+| CISO / Security Leadership | Reduce breach probability and compliance exposure | Sponsor funding, set policy guardrails, and adjudicate risk trade-offs | "ShadowMap gives us a defensible view of our cloud and SaaS footprint without linear headcount growth." |
+| Threat Intelligence & Red Teams | Expand discovery breadth and depth | Configure scan scopes, tune detection heuristics, and triage findings | "A unified recon pipeline reduces manual aggregation and noise, letting experts focus on novel attack paths." |
+| DevOps / Platform Engineering | Maintain system reliability | Provide asset inventories, DNS changes, and CI/CD integration touchpoints | "Integrating ShadowMap into delivery pipelines catches risky changes before production." |
+| Compliance & GRC | Demonstrate control effectiveness | Define evidence cadence, map outputs to control catalogs, and steward audits | "Our SBOM and vulnerability workflows become repeatable artifacts for audits and customer diligence." |
+| Business Unit Leaders | Protect revenue and customer trust | Prioritize remediation for high-value services and communicate downstream impacts | "We translate recon findings into business risk so you can manage customer-facing commitments proactively." |
+
+## Operating Model Blueprint
+1. **Program Governance**
+   - Stand up a Recon Steering Committee chaired by the CISO with quarterly reviews of coverage, findings, and remediation velocity.
+   - Define policy for target domains, cloud accounts, and third-party assets that require continuous monitoring.
+   - Establish change-management hooks so new products or acquisitions are onboarded within 30 days.
+2. **Service Delivery Pods**
+   - Form cross-functional pods (security engineer, threat analyst, DevOps liaison, and product owner) to own scoped asset groups.
+   - Equip pods with ShadowMap automations (CI jobs, scheduled scans, autonomous orchestrator) and shared dashboards.
+   - Use standardized runbooks for high-risk alerts (e.g., open storage buckets, takeover candidates) to reduce mean time to acknowledge.
+3. **Platform Engineering**
+   - Embed ShadowMap in CI/CD through pre-deployment checks (`cargo run --features gui --bin shadowmap-gui` optional for desktop triage) and post-deployment validation pipelines.
+   - Leverage the SBOM workflow to gate releases with critical vulnerability findings, integrating with ticketing systems.
+   - Instrument telemetry (scan duration, concurrency utilization) to optimize infrastructure spend.
+
+## Data & Knowledge Management
+- **Asset Inventory Synchronization** – Connect ShadowMap results with CMDB or cloud tagging strategies. Normalize naming so infrastructure-as-code repositories and recon findings reference consistent identifiers.
+- **Evidence Repository** – Store CSV, JSON, and SBOM artifacts in an immutable evidence bucket with lifecycle policies and access reviews.
+- **Threat Intelligence Feedback Loop** – Feed validated findings into detection engineering backlogs and playbooks for incident response scenarios.
+- **Lessons Learned Rituals** – After major recon discoveries, facilitate blameless reviews that trace organizational factors (ownership gaps, change management failures) and produce guardrail updates.
+
+## Implementation Phases
+1. **Foundation (Weeks 0-4)**
+   - Inventory attack surface, define scan scope, and configure credential storage.
+   - Run baseline scans, validate outputs, and establish initial remediation workflow with ticketing integration.
+   - Draft governance charter and assign pod members.
+2. **Scale-Up (Weeks 5-12)**
+   - Automate recurring scans with tuned concurrency to balance coverage and cost.
+   - Introduce autonomous orchestrator for deep cloud asset discovery and integrate high-signal alerts into SIEM.
+   - Begin SBOM + Grype workflow to deliver monthly vulnerability briefings.
+3. **Optimization (Weeks 13+)**
+   - Track metrics (coverage %, critical findings aging, remediation throughput) on executive dashboards.
+   - Expand integrations (asset tagging, CI/CD gates) and implement continuous recon for priority domains.
+   - Benchmark performance quarterly and adjust scope based on mergers, new product launches, or third-party dependencies.
+
+## Capability Maturity Ladder
+| Level | Characteristics | Next Milestone |
+|-------|-----------------|----------------|
+| Ad Hoc | Manual, inconsistent scans; remediation reactive. | Establish governance charter and repeatable baseline scans. |
+| Defined | Scheduled scans with documented runbooks and ticketing integration. | Automate SBOM generation and implement pod-based ownership. |
+| Managed | Metrics-driven operations with continuous recon and SIEM integration. | Tie remediation priorities to business impact and SLA commitments. |
+| Optimized | Recon results inform product strategy, supplier risk, and customer reporting. | Expand to predictive analytics (attack path modeling) and external sharing with key customers. |
+
+## Business Metrics & KPIs
+- **Coverage Ratio** – % of known assets monitored weekly; target 95%+ for internet-facing systems.
+- **Exposure Dwell Time** – Median hours from detection to containment for high-risk findings; trend downward quarter-over-quarter.
+- **Change Lead Time** – Days between new service launch and inclusion in ShadowMap scope; aim for <7 days.
+- **Compliance Readiness** – Number of audit requests satisfied using ShadowMap evidence; reduce manual evidence gathering by 50%.
+- **Productivity Gain** – Analyst hours saved via automation vs. manual recon baselines; reinvest 30% into proactive threat hunting.
+
+## Investment & ROI Considerations
+- Model ShadowMap operational costs against historical breach impact, regulatory fines, and customer churn to quantify payback.
+- Use cost-per-asset metrics to evaluate scaling decisions (e.g., additional cloud accounts, M&A integration).
+- Highlight qualitative ROI—improved customer trust, faster sales due diligence—during executive steering meetings.
+
+## Risk Management Guardrails
+- Define escalation paths for sensitive findings (e.g., exposed customer data) with communication plans to legal, PR, and executive leadership.
+- Maintain separation of duties: scanning configuration changes require peer review, and production credentials are stored in secrets management solutions.
+- Conduct quarterly tabletop exercises simulating supply-chain exposures using SBOM data to validate readiness.
+
+## Continuous Improvement Backlog
+- Expand plugin coverage (port fingerprinting, cloud exposures) based on emerging threats and business unit needs.
+- Incorporate machine learning prioritization once data volumes justify investment—ensure explainability for auditability.
+- Partner with vendor management to include ShadowMap outputs in third-party risk reviews, aligning procurement with security goals.
+
+## Communication Cadence
+- Weekly pod syncs for triage and remediation tracking.
+- Monthly executive scorecards summarizing KPIs, notable findings, and cross-functional blockers.
+- Quarterly board updates highlighting risk reduction, compliance posture, and roadmap alignment with corporate strategy.
+
+## Checklist for Launch Readiness
+- [ ] Governance charter approved and stakeholders assigned.
+- [ ] Baseline scan scope validated across security, DevOps, and business units.
+- [ ] Automation pipelines scheduled with alert routing configured.
+- [ ] Evidence storage and retention policies documented.
+- [ ] Metrics dashboard deployed with executive visibility.
+- [ ] Incident response and communication playbooks updated with ShadowMap inputs.
+
+Adopting ShadowMap is less about installing a tool and more about institutionalizing continuous discovery. Organizations that invest in cross-functional governance, automation, and evidence-driven decision-making will translate reconnaissance into tangible risk reduction and competitive trust advantages.


### PR DESCRIPTION
## Summary
- add an organizational adoption playbook that outlines governance, metrics, and phased rollout guidance for ShadowMap
- cross-link the new guide from the README to surface the playbook to security and business stakeholders

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68da6c52500c83269022e5b7639e292a