### PR TITLE
[docs] docs: add governance integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ ShadowMap aligns its operational safeguards with SOC 2 Trust Services Criteria a
 [Data Security and Compliance Strategy](docs/data-security.md) describes the control owners, evidence expectations, and
 validation activities that keep reconnaissance data secure throughout its lifecycle.
 
+### Application Governance & Resilience
+
+Teams that need to spot unapproved apps, fragmented data flows, or silent system failures can extend ShadowMap's
+discoveries into governance and reliability workflows using the
+[Application Governance Integration guide](docs/app-governance-integration.md). It outlines how to fuse ShadowMap outputs
+with CMDBs, data lineage tools, and observability platforms to close monitoring gaps.
+
 ### Organizational Adoption Playbook
 
 Security programs that want to operationalize ShadowMap across large enterprises can follow the

--- a/docs/app-governance-integration.md
+++ b/docs/app-governance-integration.md
@@ -1,0 +1,55 @@
+# Integrating ShadowMap With Application Governance and Resilience Programs
+
+This guide shows security and platform teams how to combine ShadowMap's reconnaissance data with
+existing governance, data management, and reliability practices to expose unapproved applications,
+untangle fragmented data flows, and surface silent system failures before they cascade into incidents.
+It assumes you already run baseline ShadowMap scans and are ready to wire the results into your
+operational tooling.
+
+## 1. Establish a Unified Discovery and Ownership Baseline
+1. **Inventory ingestion** – Export ShadowMap CSV or JSON outputs on a nightly cadence and ingest
+   them into your configuration management database (CMDB) or asset graph alongside cloud tagging
+   data. This merges ShadowMap discoveries with declared systems and flags "unknown" services.
+2. **Ownership enrichment** – Cross-reference each discovered hostname or IP with product or
+   application owners recorded in your ITSM platform. ShadowMap's metadata (headers, fingerprints,
+   takeover signals) help teams confirm whether a service is sanctioned or requires investigation.
+3. **Policy reconciliation** – Generate exception reports when ShadowMap finds assets without an
+   assigned owner or policy tag. Route them through existing governance workflows so unapproved apps
+   are captured, risk-ranked, and either registered or decommissioned.
+
+## 2. Map and Monitor Data Flows
+1. **Telemetry overlay** – Tag ShadowMap findings with data classification labels by matching DNS
+   zones or subdomains to the systems that handle regulated data. This provides a quick view of
+   where sensitive information might be processed outside official channels.
+2. **Flow reconstruction** – Combine ShadowMap port and fingerprint data with network flow logs or
+   service mesh telemetry to identify shadow integrations (e.g., unsanctioned APIs or storage
+   endpoints). Document these flows in data lineage tools to eliminate fragmentation.
+3. **Continuous validation** – Schedule ShadowMap scans after major releases or infrastructure
+   changes, and compare deltas against approved data flow diagrams. Unexpected endpoints trigger a
+   review to either document the new flow or remove it.
+
+## 3. Detect Silent System Failures Early
+1. **Heartbeat dashboards** – Feed ShadowMap's availability signals (HTTP status, TLS handshake
+   success, open ports) into observability platforms alongside synthetic checks. Sudden drops in
+   responsiveness signal silent outages in unattended services.
+2. **Takeover and misconfiguration alarms** – Treat ShadowMap's takeover risk and CORS heuristics as
+   high-signal monitors. Pipe alerts into incident management queues when previously healthy assets
+   become takeover candidates or exhibit permissive cross-origin policies.
+3. **Closed-loop remediation** – Link ShadowMap alert IDs to ticketing systems so remediation owners
+   can acknowledge, resolve, and provide evidence. Use the feedback loop to retrain heuristics and
+   reduce false negatives.
+
+## 4. Operationalize the Feedback Loop
+1. **Runbook updates** – Embed ShadowMap procedures into change management, onboarding, and incident
+   runbooks so new teams know how to interpret and respond to findings about unapproved apps or
+   abnormal flows.
+2. **Metrics and reporting** – Track key performance indicators such as unresolved shadow assets,
+   time-to-closure on policy exceptions, and frequency of silent failure detections. Present these in
+   executive scorecards to demonstrate risk reduction.
+3. **Evidence collection** – Store ShadowMap exports, alert histories, and remediation notes in your
+   evidence repository. They satisfy SOC 2, ISO 27001, and GDPR documentation demands when auditors
+   request proof of continuous monitoring.
+
+By treating ShadowMap as the discovery front-end for governance, data lineage, and reliability
+programs, teams gain a shared source of truth that continuously exposes gaps in application
+registration, data handling, and operational health.


### PR DESCRIPTION
## Summary
- add an application governance integration guide that links ShadowMap discovery to ownership, data flow, and reliability workflows
- surface the new guide from the README so teams can find governance-specific guidance

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68dad34059f883269bc3f3fa1db79e32